### PR TITLE
Explicitely insert quotation marks in "convert JSON to string" use case output

### DIFF
--- a/source/_usecases/convert-JSON-to-string.md
+++ b/source/_usecases/convert-JSON-to-string.md
@@ -17,5 +17,5 @@ JSON.stringify(object);
 ```
 
 <pre class="output">
-{"id":1,"name":"Leanne Graham"}
+"{"id":1,"name":"Leanne Graham"}"
 </pre>

--- a/source/_usecases/convert-JSON-to-string.md
+++ b/source/_usecases/convert-JSON-to-string.md
@@ -1,6 +1,6 @@
 ---
 extends: _layouts.usecase
-date: 2018-01-12
+date: 2018-03-6
 link: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 related: parse-JSON-string
 category: JSON


### PR DESCRIPTION
- [X] Check [CONTRIBUTING.md](https://github.com/jadjoubran/codetogo.io/blob/master/CONTRIBUTING.md)?
- [ ] Double check the use case file name?
- [ ] Update or remove the `mdn` link?
- [ ] Update or remove the `related` use cases?
- [ ] Update the category? (if necessary)
- [ ] Update the date?

I believe I did not have to go through these steps, as I'm only modifying an existing use case in a really minor way. Let me know if I need to change anything else @jadjoubran :)